### PR TITLE
Added info about hook URL to address issue #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,12 @@ It is really simple to set up with a few clicks. Follow these steps:
     <small>Screenshot:</small><br>
     <img src="http://cl.ly/image/3k3j2q263K3M/slack-configurehook.png" title="Screenshot">
 
+    **Note:** The hook URL should like this:
+    
+    `https://random-app-name.herokuapp.com/new-activity`
+    
+    The `/new-activity` part is required for the hook to work.
+    
+
 Hooks are now configured. Post a comment on Opbeat to test it out!
 


### PR DESCRIPTION
To avoid issues and confusion, I've added a note about how the hook URL should look and that the `/new-activity` part is required.

Thanks to @snario for pointing this out.
